### PR TITLE
Hotfix(MInference): fix vllm>=0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ pipe(prompt, max_length=10)
 ```
 
 for vLLM,
-> For now, please use vllm==0.4.x
+> For now, please use vllm>=0.4.1
 
 ```diff
 from vllm import LLM, SamplingParams

--- a/minference/version.py
+++ b/minference/version.py
@@ -8,7 +8,7 @@ _MINOR = "1"
 _PATCH = "4"
 # This is mainly for nightly builds which have the suffix ".dev$DATE". See
 # https://semver.org/#is-v123-a-semantic-version for the semantics.
-_SUFFIX = ".post3"
+_SUFFIX = ".post4"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
 VERSION = "{0}.{1}.{2}{3}".format(_MAJOR, _MINOR, _PATCH, _SUFFIX)


### PR DESCRIPTION
# What does this PR do?

Fixes #42, not found `cache_ops`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue? #42
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

@iofu728